### PR TITLE
[done: :remove] flag for spinners.

### DIFF
--- a/lib/progress_bar/spinner.ex
+++ b/lib/progress_bar/spinner.ex
@@ -44,11 +44,15 @@ defmodule ProgressBar.Spinner do
   end
 
   defp render_done(format) do
-    IO.write [
-      Utils.ansi_prefix,
-      format[:done],
-      "\n",
-    ]
+    case format[:done] do
+      :remove -> IO.write [Utils.ansi_prefix]
+      _ ->
+        IO.write [
+          Utils.ansi_prefix,
+          format[:done],
+          "\n",
+        ]
+    end
   end
 
   defp get_frames(theme) when is_atom(theme), do: Keyword.fetch!(@themes, theme)

--- a/lib/progress_bar/spinner.ex
+++ b/lib/progress_bar/spinner.ex
@@ -45,8 +45,9 @@ defmodule ProgressBar.Spinner do
 
   defp render_done(format) do
     case format[:done] do
-      :remove -> IO.write [Utils.ansi_prefix]
-      _ ->
+      :remove ->
+        IO.write [Utils.ansi_prefix]
+      _       ->
         IO.write [
           Utils.ansi_prefix,
           format[:done],

--- a/test/spinner_test.exs
+++ b/test/spinner_test.exs
@@ -74,6 +74,18 @@ defmodule SpinnerTest do
     assert_received :fun_return
   end
 
+  test "[done: :remove] flag" do
+    io = capture_io fn ->
+      ProgressBar.render_spinner([done: :remove], fn -> :noop end)
+      IO.puts "after"
+    end
+
+    assert split_frames(io) == [
+      "/ Loading…",
+      "after",
+    ]
+  end
+
   defp split_frames(string) do
     string
     |> String.strip


### PR DESCRIPTION
I added a flag for spinners that lets you remove them when done spinning. I'm using it in my weather app: https://github.com/itsgreggreg/weather while loading data from remote services but then when the data is displayed we don't really need and indicator that it has been loaded. :)

Also added a test.
