### PR TITLE
Fix looping infinitely when progress is over 100%

### DIFF
--- a/lib/progress_bar/determinate.ex
+++ b/lib/progress_bar/determinate.ex
@@ -11,7 +11,9 @@ defmodule ProgressBar.Determinate do
     width: :auto,
   ]
 
-  def render(current, total, custom_format \\ @default_format) do
+  def render(current, total, custom_format \\ @default_format)
+    when current <= total
+  do
     format = Keyword.merge(@default_format, custom_format)
 
     percent = current / total * 100 |> round

--- a/test/determinate_test.exs
+++ b/test/determinate_test.exs
@@ -18,6 +18,12 @@ defmodule DeterminateTest do
     assert_bar ProgressBar.render(3, 3, @format) == "|====================================================================================================| 100%"
   end
 
+  test "does not render progress above 100%" do
+    assert_raise FunctionClauseError, fn ->
+      ProgressBar.render(4, 3, @format)
+    end
+  end
+
   test "includes ANSI sequences to clear and re-write the line" do
     bar = capture_io(fn -> ProgressBar.render(1, 1) end)
     assert String.starts_with?(bar, "\e[2K\r")


### PR DESCRIPTION
This adds a function clause so that when the progress is over 100%, a `FunctionClauseError` is generated instead of getting stuck in an infinite loop.
