### PR TITLE
Prevent GenServer errors

### DIFF
--- a/lib/progress_bar/animation_server.ex
+++ b/lib/progress_bar/animation_server.ex
@@ -10,7 +10,11 @@ defmodule ProgressBar.AnimationServer do
   end
 
   def stop do
-    GenServer.call(@name, :stop)
+    if Process.whereis(@name) do
+      GenServer.call(@name, :stop)
+    else
+      :ok
+    end
   end
 
   # GenServer API


### PR DESCRIPTION
My tests run mix tasks which use ProgressBar. Occasionally, the `ProgressBar.AnimationServer` will crash or something, causing `AnimationServer.stop` to raise an error, causing the entire test to crash.

Here's an example error:

```
     ** (exit) exited in: GenServer.call(:animation_server, :stop, 5000)
         ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
     stacktrace:
       (elixir) lib/gen_server.ex:729: GenServer.call/3
       lib/progress_bar/spinner.ex:29: ProgressBar.Spinner.render/2
       (elixir) lib/enum.ex:1229: Enum."-map/2-lists^map/1-0-"/2
       (mix) lib/mix/task.ex:294: Mix.Task.run_task/3
       (ex_unit) lib/ex_unit/capture_io.ex:146: ExUnit.CaptureIO.do_capture_io/2
       (ex_unit) lib/ex_unit/capture_io.ex:119: ExUnit.CaptureIO.do_capture_io/3
       test/loaders/search_loader_test.exs:38: (test)
```