### PR TITLE
Count suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,25 @@ Instead of:
 
     …============| 100%
 
-#### `bytes: true`
+#### `suffix: :count`
+
+This option causes the values to be printed on the suffix of your progress bar.
+
+``` elixir
+ProgressBar.render(9_751, 10_000, suffix: :count)
+```
+
+Output:
+
+    …=========   |  97% (9751/10000)
+
+
+#### `suffix: :bytes`
 
 This option causes the values to be treated as bytes of data, showing those amounts next to the bar.
 
 ``` elixir
-ProgressBar.render(2_034_237, 2_097_152, bytes: true)
+ProgressBar.render(2_034_237, 2_097_152, suffix: :bytes)
 ```
 
 Output:

--- a/examples/00-gif.exs
+++ b/examples/00-gif.exs
@@ -33,7 +33,7 @@ format = [
   blank_color: [IO.ANSI.magenta],
   bar: "█",
   blank: "░",
-  bytes: true,
+  suffix: :bytes,
 ]
 
 Enum.each 0..1_000, fn (i) ->

--- a/examples/04-bytes.exs
+++ b/examples/04-bytes.exs
@@ -2,6 +2,6 @@ IO.puts ""
 IO.puts "Bytes of data:"
 
 Enum.each 0..3_000, fn (i) ->
-  ProgressBar.render((i*1000), 3_000_000, bytes: true)
+  ProgressBar.render((i*1000), 3_000_000, suffix: :bytes)
   :timer.sleep 1
 end

--- a/lib/progress_bar/determinate.ex
+++ b/lib/progress_bar/determinate.ex
@@ -7,7 +7,6 @@ defmodule ProgressBar.Determinate do
     left: "|",
     right: "|",
     percent: true,
-    bytes: false,
     suffix: false,
     bar_color: [],
     blank_color: [],
@@ -16,16 +15,13 @@ defmodule ProgressBar.Determinate do
 
   def render(current, total, custom_format \\ @default_format)
   def render(current, total, custom_format) when current <= total do
-    format =
-      @default_format
-      |> Keyword.merge(custom_format)
-      |> Enum.into(%{})
+    format = Keyword.merge(@default_format, custom_format)
 
     percent = current / total * 100 |> round
 
     suffix = [
       formatted_percent(format[:percent], percent),
-      format |> get_suffix() |> formatted_suffix(current, total),
+      formatted_suffix(format[:suffix], current, total),
       newline_if_complete(current, total),
     ]
 
@@ -38,9 +34,6 @@ defmodule ProgressBar.Determinate do
   end
 
   # Private
-
-  defp get_suffix(%{suffix: false, bytes: true}), do: :bytes
-  defp get_suffix(%{suffix: suffix}), do: suffix
 
   defp formatted_percent(false, _) do
     ""

--- a/lib/progress_bar/determinate.ex
+++ b/lib/progress_bar/determinate.ex
@@ -1,4 +1,6 @@
 defmodule ProgressBar.Determinate do
+  alias ProgressBar.Bytes
+
   @default_format [
     bar: "=",
     blank: " ",
@@ -6,21 +8,24 @@ defmodule ProgressBar.Determinate do
     right: "|",
     percent: true,
     bytes: false,
+    suffix: false,
     bar_color: [],
     blank_color: [],
     width: :auto,
   ]
 
   def render(current, total, custom_format \\ @default_format)
-    when current <= total
-  do
-    format = Keyword.merge(@default_format, custom_format)
+  def render(current, total, custom_format) when current <= total do
+    format =
+      @default_format
+      |> Keyword.merge(custom_format)
+      |> Enum.into(%{})
 
     percent = current / total * 100 |> round
 
     suffix = [
       formatted_percent(format[:percent], percent),
-      bytes(format[:bytes], current, total),
+      format |> get_suffix() |> formatted_suffix(current, total),
       newline_if_complete(current, total),
     ]
 
@@ -34,18 +39,24 @@ defmodule ProgressBar.Determinate do
 
   # Private
 
-  defp formatted_percent(false, _), do: ""
+  defp get_suffix(%{suffix: false, bytes: true}), do: :bytes
+  defp get_suffix(%{suffix: suffix}), do: suffix
+
+  defp formatted_percent(false, _) do
+    ""
+  end
   defp formatted_percent(true, number) do
-    " " <> String.pad_leading(Integer.to_string(number), 3) <> "%"
+    number
+    |> Integer.to_string()
+    |> String.pad_leading(4)
+    |> Kernel.<>("%")
   end
 
-  defp bytes(false, _, _), do: ""
-  defp bytes(true, total, total) do
-    " (" <> ProgressBar.Bytes.format(total) <> ")"
-  end
-  defp bytes(true, current, total) do
-    " (" <> ProgressBar.Bytes.format(current, total) <> ")"
-  end
+  defp formatted_suffix(:count, total, total), do: " (#{total})"
+  defp formatted_suffix(:count, current, total), do: " (#{current}/#{total})"
+  defp formatted_suffix(:bytes, total, total), do: " (#{Bytes.format(total)})"
+  defp formatted_suffix(:bytes, current, total), do: " (#{Bytes.format(current, total)})"
+  defp formatted_suffix(false, _, _), do: ""
 
   defp newline_if_complete(total, total), do: "\n"
   defp newline_if_complete(_, _), do: ""

--- a/test/determinate_test.exs
+++ b/test/determinate_test.exs
@@ -91,11 +91,19 @@ defmodule DeterminateTest do
     assert bar =~ IO.chardata_to_string([" ", IO.ANSI.reset])
   end
 
-  test "bytes: true" do
+  test "suffix: :bytes" do
     mb = 1_000_000
-    format = [bytes: true, width: @width]
+    format = [suffix: :bytes, width: @width]
     assert_bar ProgressBar.render(0, mb, format)      == "|                                                                                                    |   0% (0.00/1.00 MB)"
     assert_bar ProgressBar.render((mb/2), mb, format) == "|==================================================                                                  |  50% (0.50/1.00 MB)"
     assert_bar ProgressBar.render(mb, mb, format)     == "|====================================================================================================| 100% (1.00 MB)"
+  end
+
+  test "suffix: :count" do
+    mb = 100
+    format = [suffix: :count, width: @width]
+    assert_bar ProgressBar.render(0, mb, format)      == "|                                                                                                    |   0% (0/100)"
+    assert_bar ProgressBar.render(50, mb, format) == "|==================================================                                                  |  50% (50/100)"
+    assert_bar ProgressBar.render(mb, mb, format)     == "|====================================================================================================| 100% (100)"
   end
 end

--- a/test/determinate_test.exs
+++ b/test/determinate_test.exs
@@ -102,8 +102,8 @@ defmodule DeterminateTest do
   test "suffix: :count" do
     mb = 100
     format = [suffix: :count, width: @width]
-    assert_bar ProgressBar.render(0, mb, format)      == "|                                                                                                    |   0% (0/100)"
+    assert_bar ProgressBar.render(0, mb, format)  == "|                                                                                                    |   0% (0/100)"
     assert_bar ProgressBar.render(50, mb, format) == "|==================================================                                                  |  50% (50/100)"
-    assert_bar ProgressBar.render(mb, mb, format)     == "|====================================================================================================| 100% (100)"
+    assert_bar ProgressBar.render(mb, mb, format) == "|====================================================================================================| 100% (100)"
   end
 end


### PR DESCRIPTION
This PR has:

- A new option called `suffix` which allows the options `:bytes` and `:count`
- Some fixes to elixir 1.4 and 1.5 warnings
- Some indentation and style changes to match the community styleguide