### PR TITLE
Fix compatibility with newer versions of decimal library

### DIFF
--- a/lib/progress_bar/bytes.ex
+++ b/lib/progress_bar/bytes.ex
@@ -26,6 +26,13 @@ defmodule ProgressBar.Bytes do
   defp to_s(number) do
     # Always show 2 decimals. Looks jumpy otherwise when numbers change.
     # Float.floor has surprising behaviour.
-    number |> Decimal.new() |> Decimal.round(2, :floor) |> Decimal.to_string()
+    number |> to_decimal() |> Decimal.round(2, :floor) |> Decimal.to_string()
+  end
+
+  # Use from_float/1 if available, otherwise Decimal will loudly warn.
+  if Keyword.has_key?(Decimal.module_info(:exports), :from_float) do
+    defp to_decimal(float), do: Decimal.from_float(float)
+  else
+    defp to_decimal(float), do: Decimal.new(float)
   end
 end


### PR DESCRIPTION
As of Decimal 1.6.0, `Decimal.new(n) when is_float(n)` will emit a deprecation warning, recommending to use `Decimal.from_float(n)` instead.

If `Decimal.from_float/1` always existed, the code could just be updated to use it. However, even as of Decimal 1.4.0, `Decimal.from_float/1` didn't exist. Therefore, if compatibility with older versions of Decimal is desired, it is best to do "feature detection" and use `from_float/1` only if it is available.

This PR does so, with the feature detection happening at compile-time for no added runtime cost.