### PR TITLE
Fix two compilation warnings in Elixir 1.11

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule ProgressBar.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   def package do

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule ProgressBar.Mixfile do
 
   defp deps do
     [
-      {:decimal, "~> 1.0"}
+      {:decimal, "~> 2.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"decimal": {:hex, :decimal, "1.4.0", "fac965ce71a46aab53d3a6ce45662806bdd708a4a95a65cde8a12eb0124a1333", [:mix], []},
+%{
+  "decimal": {:hex, :decimal, "2.0.0", "a78296e617b0f5dd4c6caf57c714431347912ffb1d0842e998e9792b5642d697", [:mix], [], "hexpm", "34666e9c55dea81013e77d9d87370fe6cb6291d1ef32f46a1600230b1d44f577"},
   "earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+}


### PR DESCRIPTION
Hello,

I was taking a look at the code and ran into a couple of compilation warnings with Elixir 1.11 which I thought I'd try to fix.

First, there are some warnings about Decimal being used but not being specified in the deps (which clearly isn't true)
```
warning: Decimal.round/3 defined in application :decimal is used by the current application but the current application does not directly depend on :decimal. To fix this, you must do one of:

  1. If :decimal is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :decimal is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :decimal, you may optionally skip this warning by adding [xref: [exclude: Decimal] to your "def project" in mix.exs

  lib/progress_bar/bytes.ex:29: ProgressBar.Bytes.to_s/1

warning: Decimal.to_string/1 defined in application :decimal is used by the current application but the current application does not directly depend on :decimal. To fix this, you must do one of:

  1. If :decimal is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :decimal is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :decimal, you may optionally skip this warning by adding [xref: [exclude: Decimal] to your "def project" in mix.exs

  lib/progress_bar/bytes.ex:29: ProgressBar.Bytes.to_s/1
```
Removing the `:applications` config means it should [infer the application list from the deps](https://github.com/elixir-lang/elixir/issues/10422#issuecomment-707268278).

Second, there is a deprecation warning about Decimal using `Integer.to_char_list/1`, upgrading to v2.0 fixes this warning.