### PR TITLE
No need to import the Decimal lib for this

### DIFF
--- a/lib/progress_bar/bytes.ex
+++ b/lib/progress_bar/bytes.ex
@@ -24,15 +24,7 @@ defmodule ProgressBar.Bytes do
   defp divisor_and_unit(_bytes), do: {@mb, "MB"}
 
   defp to_s(number) do
-    # Always show 2 decimals. Looks jumpy otherwise when numbers change.
-    # Float.floor has surprising behaviour.
-    number |> to_decimal() |> Decimal.round(2, :floor) |> Decimal.to_string()
-  end
-
-  # Use from_float/1 if available, otherwise Decimal will loudly warn.
-  if Keyword.has_key?(Decimal.module_info(:exports), :from_float) do
-    defp to_decimal(float), do: Decimal.from_float(float)
-  else
-    defp to_decimal(float), do: Decimal.new(float)
+    truncated = trunc(number * 100) / 100
+    :io_lib.format("~.2f", [truncated]) |> to_string()
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,6 @@ defmodule ProgressBar.Mixfile do
 
   defp deps do
     [
-      {:decimal, "~> 2.0"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
The hard version set on the Decimal library was causing some conflicts, rather than just change the version it is less code to simply remove the dependency entirely.

Addresses https://github.com/henrik/progress_bar/issues/31 in a more permanent way